### PR TITLE
Add GitHub actions workflow to build and run integration tests

### DIFF
--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+mkdir -p $TESTGAME_DIR/libsocket
+cp *.rb $TESTGAME_DIR/libsocket
+
+# TODO: Start simple TCP server
+
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./dragonruby $TESTGAME_DIR
+
+if [ -f $TESTGAME_DIR/success ]; then
+  echo "Tests finished successfully."
+  exit 0
+else
+  echo "Tests failed."
+  exit 1
+fi

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           curl -L -O https://github.com/kfischer-okarin/dragonruby-for-ci/releases/download/$DR_VERSION/dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
           unzip dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+          chmod u+x ./dragonruby
       - name: Build extension
         run: |
           mkdir -p $TESTGAME_DIR/native/linux-amd64/
@@ -74,6 +75,7 @@ jobs:
         run: |
           curl -L -O https://github.com/kfischer-okarin/dragonruby-for-ci/releases/download/$DR_VERSION/dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
           unzip dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+          chmod u+x ./dragonruby
       - name: Build extension
         run: |
           mkdir -p $TESTGAME_DIR/native/macos/

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           mkdir -p $TESTGAME_DIR/native/macos/
           clang -shared \
+                -arch x86_64 -arch arm64 \
                 -isystem include -I . -fPIC \
                 -o $TESTGAME_DIR/native/macos/libsocket.dylib \
                 libsocket-bind.c

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -32,12 +32,12 @@ jobs:
                 -isystem include -I . -fPIC \
                 -o $TESTGAME_DIR/native/linux-amd64/libsocket.so \
                 libsocket-bind.c
+      - name: Run tests
+        run: .github/workflows/run_tests.sh
       - uses: actions/upload-artifact@v3
         with:
           name: libsocket.so (linux-amd64)
           path: '${{ env.TESTGAME_DIR }}/native/linux-amd64/libsocket.so'
-      - name: Run tests
-        run: .github/workflows/run_tests.sh
   windows:
     runs-on: windows-latest
     defaults:
@@ -63,12 +63,12 @@ jobs:
                 -isystem include -I . -lws2_32 \
                 -o $TESTGAME_DIR/native/windows-amd64/libsocket.dll \
                 libsocket-bind.c
+      - name: Run tests
+        run: .github/workflows/run_tests.sh
       - uses: actions/upload-artifact@v3
         with:
           name: libsocket.dll (windows-amd64)
           path: '${{ env.TESTGAME_DIR }}/native/windows-amd64/libsocket.dll'
-      - name: Run tests
-        run: .github/workflows/run_tests.sh
   macos:
     runs-on: macos-latest
     steps:
@@ -88,9 +88,10 @@ jobs:
                 -isystem include -I . -fPIC \
                 -o $TESTGAME_DIR/native/macos/libsocket.dylib \
                 libsocket-bind.c
+      - name: Run tests
+        run: .github/workflows/run_tests.sh
       - uses: actions/upload-artifact@v3
         with:
           name: libsocket.dylib (macos)
           path: '${{ env.TESTGAME_DIR }}/native/macos/libsocket.dylib'
-      - name: Run tests
-        run: .github/workflows/run_tests.sh
+

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,0 +1,87 @@
+name: Test and Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+      - github-action
+
+env:
+  DR_VERSION: 4.7
+  DR_LICENSE_TIER: pro
+  TESTGAME_DIR: .github/workflows/testgame
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download dragonruby
+        env:
+          DR_PLATFORM: linux-amd64
+        run: |
+          curl -L -O https://github.com/kfischer-okarin/dragonruby-for-ci/releases/download/$DR_VERSION/dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+          unzip dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+      - name: Build extension
+        run: |
+          mkdir -p $TESTGAME_DIR/native/linux-amd64/
+          clang -shared \
+                -isystem include -I . -fPIC \
+                -o $TESTGAME_DIR/native/linux-amd64/libsocket.so \
+                libsocket-bind.c
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libsocket.so (linux-amd64)
+          path: '${{ env.TESTGAME_DIR }}/native/linux-amd64/libsocket.so'
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          install: mingw-w64-x86_64-clang mingw-w64-x86_64-lld unzip
+      - name: Download dragonruby
+        env:
+          DR_PLATFORM: windows-amd64
+        run: |
+          curl -L -O https://github.com/kfischer-okarin/dragonruby-for-ci/releases/download/$DR_VERSION/dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+          unzip dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+      - name: Build extension
+        run: |
+          mkdir -p $TESTGAME_DIR/native/windows-amd64/
+          clang -shared \
+                --target=x86_64-w64-mingw32 \
+                -fuse-ld=lld \
+                -isystem include -I . -lws2_32 \
+                -o $TESTGAME_DIR/native/windows-amd64/libsocket.dll \
+                libsocket-bind.c
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libsocket.dll (windows-amd64)
+          path: '${{ env.TESTGAME_DIR }}/native/windows-amd64/libsocket.dll'
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download dragonruby
+        env:
+          DR_PLATFORM: macos
+        run: |
+          curl -L -O https://github.com/kfischer-okarin/dragonruby-for-ci/releases/download/$DR_VERSION/dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+          unzip dragonruby-for-ci-$DR_VERSION-$DR_LICENSE_TIER-$DR_PLATFORM.zip
+      - name: Build extension
+        run: |
+          mkdir -p $TESTGAME_DIR/native/macos/
+          clang -shared \
+                -isystem include -I . -fPIC \
+                -o $TESTGAME_DIR/native/macos/libsocket.dylib \
+                libsocket-bind.c
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libsocket.dylib (macos)
+          path: '${{ env.TESTGAME_DIR }}/native/macos/libsocket.dylib'

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           name: libsocket.so (linux-amd64)
           path: '${{ env.TESTGAME_DIR }}/native/linux-amd64/libsocket.so'
+      - name: Run tests
+        run: .github/workflows/run_tests.sh
   windows:
     runs-on: windows-latest
     defaults:
@@ -65,6 +67,8 @@ jobs:
         with:
           name: libsocket.dll (windows-amd64)
           path: '${{ env.TESTGAME_DIR }}/native/windows-amd64/libsocket.dll'
+      - name: Run tests
+        run: .github/workflows/run_tests.sh
   macos:
     runs-on: macos-latest
     steps:
@@ -88,3 +92,5 @@ jobs:
         with:
           name: libsocket.dylib (macos)
           path: '${{ env.TESTGAME_DIR }}/native/macos/libsocket.dylib'
+      - name: Run tests
+        run: .github/workflows/run_tests.sh

--- a/.github/workflows/testgame/.gitignore
+++ b/.github/workflows/testgame/.gitignore
@@ -1,0 +1,5 @@
+# Is copied from the root directory before running tests, so ignore to avoid duplication
+libsocket
+
+# file created when test succeeds
+success

--- a/.github/workflows/testgame/app/main.rb
+++ b/.github/workflows/testgame/app/main.rb
@@ -1,0 +1,12 @@
+# No functionality yet, so require is commented out for now.
+# require 'libsocket/require.rb'
+
+def tick(args)
+  # $gtk.ffi_misc.gtk_dlopen('libsocket')
+  if FFI.const_defined?(:SOCKET)
+    $gtk.write_file('success', 'success')
+  else
+    puts 'Failed to load libsocket'
+  end
+  $gtk.request_quit
+end

--- a/.github/workflows/testgame/app/main.rb
+++ b/.github/workflows/testgame/app/main.rb
@@ -2,7 +2,7 @@
 # require 'libsocket/require.rb'
 
 def tick(args)
-  # $gtk.ffi_misc.gtk_dlopen('libsocket')
+  $gtk.ffi_misc.gtk_dlopen('libsocket')
   if FFI.const_defined?(:SOCKET)
     $gtk.write_file('success', 'success')
   else


### PR DESCRIPTION
- Added a GitHub actions workflow which builds the extension for all 3 platforms and runs a simple test to see if Dragonruby can load the lib
  - Since there is no way to actually connect to a TCP server yet I just test whether the `FFI::SOCKET` module is successfully defined
  - Failing test run can be seen [here](https://github.com/bedwardly-down/dragonruby-cext-libsocket/actions/runs/4651817129) (failing since I commented out the DLL load on purpose to see if the test would actually fail)
  - Success can be seen [here](https://github.com/bedwardly-down/dragonruby-cext-libsocket/actions/runs/4651822532)