### PR TITLE
Trigger Github Action Runs on any branch

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - master
-      - github-action
 
 env:
   DR_VERSION: 4.7

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -2,7 +2,6 @@ name: Test and Build
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
 
 env:


### PR DESCRIPTION
The original workflow was set to run only on specific branches but at the moment there's no reason why it shouldn't run on all branches... considering minutes etc are free..... So I fixed that