### PR TITLE
Separate Build Job & Test Job

### DIFF
--- a/.github/workflows/test-and-build-for-one-platform.yml
+++ b/.github/workflows/test-and-build-for-one-platform.yml
@@ -28,11 +28,13 @@ env:
   TESTGAME_DIR: .github/workflows/testgame
 
 jobs:
-  build_and_test:
+  build:
     runs-on: ${{ inputs.runner }}
     defaults:
       run:
         shell: bash
+    outputs:
+      dr_platform: ${{ steps.determine_dr_platform.outputs.dr_platform }}
     steps:
       - uses: actions/checkout@v3
       - name: Determine DragonRuby platform
@@ -45,9 +47,25 @@ jobs:
         if: runner.os == 'Windows'
       - name: Build extension
         run: scripts/build.sh $TESTGAME_DIR/native/${{ steps.determine_dr_platform.outputs.dr_platform }}
-      - name: Run tests
-        run: .github/workflows/run_tests.sh
       - uses: actions/upload-artifact@v3
         with:
           name: dragonruby-cext-libsocket-${{ steps.determine_dr_platform.outputs.dr_platform }}
           path: ${{ env.TESTGAME_DIR }}/native/${{ steps.determine_dr_platform.outputs.dr_platform }}/*
+  test:
+    needs:
+      - build
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download dragonruby
+        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.dr_version }}
+      - name: Download extension
+        uses: actions/download-artifact@v3
+        with:
+          name: dragonruby-cext-libsocket-${{ needs.build.outputs.dr_platform }}
+          path: ${{ env.TESTGAME_DIR }}/native/${{ needs.build.outputs.dr_platform }}
+      - name: Run tests
+        run: .github/workflows/run_tests.sh

--- a/.github/workflows/test-and-build-for-one-platform.yml
+++ b/.github/workflows/test-and-build-for-one-platform.yml
@@ -1,0 +1,53 @@
+name: Test and Build (Single Platform)
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Runner to build on'
+        required: true
+        type: choice
+        options:
+          - ubuntu-22.04
+          - windows-2022
+          - macos-12
+      dr_version:
+        description: 'DragonRuby version to build with'
+        type: string
+        default: '4.7'
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      dr_version:
+        type: string
+        default: '4.7'
+
+env:
+  TESTGAME_DIR: .github/workflows/testgame
+
+jobs:
+  build_and_test:
+    runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Determine DragonRuby platform
+        id: determine_dr_platform
+        run: echo "dr_platform=$(scripts/dr_platform.sh)" >> "$GITHUB_OUTPUT"
+      - name: Download dragonruby
+        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.dr_version }}
+      - name: Windows build settings
+        run: echo "MINGW_DIR=/C/ProgramData/chocolatey/lib/mingw/tools/install/mingw64" >> $GITHUB_ENV
+        if: runner.os == 'Windows'
+      - name: Build extension
+        run: scripts/build.sh $TESTGAME_DIR/native/${{ steps.determine_dr_platform.outputs.dr_platform }}
+      - name: Run tests
+        run: .github/workflows/run_tests.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dragonruby-cext-libsocket-${{ steps.determine_dr_platform.outputs.dr_platform }}
+          path: ${{ env.TESTGAME_DIR }}/native/${{ steps.determine_dr_platform.outputs.dr_platform }}/*

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -23,28 +23,19 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
+      - name: Determine DragonRuby platform
+        id: determine_dr_platform
+        run: echo "dr_platform=$(scripts/dr_platform.sh)" >> "$GITHUB_OUTPUT"
       - name: Download dragonruby
         run: .github/workflows/download_dr_for_ci.sh ${{ matrix.dr_version }}
       - name: Windows build settings
         run: echo "MINGW_DIR=/C/ProgramData/chocolatey/lib/mingw/tools/install/mingw64" >> $GITHUB_ENV
         if: runner.os == 'Windows'
       - name: Build extension
-        run: scripts/build.sh $TESTGAME_DIR/native/$(scripts/dr_platform.sh)
+        run: scripts/build.sh $TESTGAME_DIR/native/${{ steps.determine_dr_platform.outputs.dr_platform }}
       - name: Run tests
         run: .github/workflows/run_tests.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: dragonruby-cext-libsocket-linux-amd64
-          path: ${{ env.TESTGAME_DIR }}/native/linux-amd64/libsocket.so
-        if: runner.os == 'Linux'
-      - uses: actions/upload-artifact@v3
-        with:
-          name: dragonruby-cext-libsocket-windows-amd64
-          path: ${{ env.TESTGAME_DIR }}/native/windows-amd64/libsocket.dll
-        if: runner.os == 'Windows'
-      - uses: actions/upload-artifact@v3
-        with:
-          name: dragonruby-cext-libsocket-macos
-          path: '${{ env.TESTGAME_DIR }}/native/macos/libsocket.dylib'
-        if: runner.os == 'macOS'
-
+          name: dragonruby-cext-libsocket-${{ steps.determine_dr_platform.outputs.dr_platform }}
+          path: ${{ env.TESTGAME_DIR }}/native/${{ steps.determine_dr_platform.outputs.dr_platform }}/*

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,4 +1,4 @@
-name: Test and Build
+name: Test and Build (All Platforms)
 
 on:
   workflow_dispatch:
@@ -17,25 +17,7 @@ jobs:
           - macos-12
         dr_version:
           - '4.7'
-    runs-on: ${{ matrix.runner }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v3
-      - name: Determine DragonRuby platform
-        id: determine_dr_platform
-        run: echo "dr_platform=$(scripts/dr_platform.sh)" >> "$GITHUB_OUTPUT"
-      - name: Download dragonruby
-        run: .github/workflows/download_dr_for_ci.sh ${{ matrix.dr_version }}
-      - name: Windows build settings
-        run: echo "MINGW_DIR=/C/ProgramData/chocolatey/lib/mingw/tools/install/mingw64" >> $GITHUB_ENV
-        if: runner.os == 'Windows'
-      - name: Build extension
-        run: scripts/build.sh $TESTGAME_DIR/native/${{ steps.determine_dr_platform.outputs.dr_platform }}
-      - name: Run tests
-        run: .github/workflows/run_tests.sh
-      - uses: actions/upload-artifact@v3
-        with:
-          name: dragonruby-cext-libsocket-${{ steps.determine_dr_platform.outputs.dr_platform }}
-          path: ${{ env.TESTGAME_DIR }}/native/${{ steps.determine_dr_platform.outputs.dr_platform }}/*
+    uses: ./.github/workflows/test-and-build-for-one-platform.yml
+    with:
+      runner: ${{ matrix.runner }}
+      dr_version: ${{ matrix.dr_version }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -17,6 +17,7 @@ jobs:
           - macos-12
         dr_version:
           - '4.7'
+      fail-fast: false
     uses: ./.github/workflows/test-and-build-for-one-platform.yml
     with:
       runner: ${{ matrix.runner }}


### PR DESCRIPTION
This makes some changes to the GH actions architecture.....

## Before
- One Workflow with one Job doing both build and test... ran 3 times in parallel (once for each platform)

## After
- One Parent Workflow ("Test and Build (All Platforms)") which is run for each platform and calls a child workflow ("Test and Build (Single Platform)") for each platform
- The Child workflow has two jobs that run sequentially
  - Build: Builds and produces the artifact using the minimum required DR version
  - Test: Uses the produced artifact and runs tests.
    - Currently, that is also done with that one DR Version... but in my next PR I will add the fan out setting to run the tests with several DR versions
 
 This splitting up of workflows has also the advantage that once this is merged to master you can also just manually call a build for any single platform and DR version on demand (as the Repo maintainer only of course)