### PR TITLE
Test with several DR versions

### DIFF
--- a/.github/workflows/test-and-build-for-one-platform.yml
+++ b/.github/workflows/test-and-build-for-one-platform.yml
@@ -22,7 +22,7 @@ on:
         type: string
       build_dr_version:
         type: string
-        default: '4.7'
+        default: '4.7' # Minimum required version
 
 env:
   TESTGAME_DIR: .github/workflows/testgame
@@ -54,6 +54,12 @@ jobs:
   test:
     needs:
       - build
+    strategy:
+      matrix:
+        dr_version:
+          - ${{ inputs.build_dr_version }}
+          - '4.8' # Current DR version
+      fail-fast: false
     runs-on: ${{ inputs.runner }}
     defaults:
       run:
@@ -61,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download dragonruby
-        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.build_dr_version }}
+        run: .github/workflows/download_dr_for_ci.sh ${{ matrix.dr_version }}
       - name: Download extension
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-and-build-for-one-platform.yml
+++ b/.github/workflows/test-and-build-for-one-platform.yml
@@ -11,8 +11,8 @@ on:
           - ubuntu-22.04
           - windows-2022
           - macos-12
-      dr_version:
-        description: 'DragonRuby version to build with'
+      build_dr_version:
+        description: 'DragonRuby version headers to build with'
         type: string
         default: '4.7'
   workflow_call:
@@ -20,7 +20,7 @@ on:
       runner:
         required: true
         type: string
-      dr_version:
+      build_dr_version:
         type: string
         default: '4.7'
 
@@ -41,7 +41,7 @@ jobs:
         id: determine_dr_platform
         run: echo "dr_platform=$(scripts/dr_platform.sh)" >> "$GITHUB_OUTPUT"
       - name: Download dragonruby
-        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.dr_version }}
+        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.build_dr_version }}
       - name: Windows build settings
         run: echo "MINGW_DIR=/C/ProgramData/chocolatey/lib/mingw/tools/install/mingw64" >> $GITHUB_ENV
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download dragonruby
-        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.dr_version }}
+        run: .github/workflows/download_dr_for_ci.sh ${{ inputs.build_dr_version }}
       - name: Download extension
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -15,10 +15,7 @@ jobs:
           - ubuntu-22.04
           - windows-2022
           - macos-12
-        dr_version:
-          - '4.7'
       fail-fast: false
     uses: ./.github/workflows/test-and-build-for-one-platform.yml
     with:
       runner: ${{ matrix.runner }}
-      dr_version: ${{ matrix.dr_version }}


### PR DESCRIPTION
Changed the parameter to the "single platform build job" to specify the DR version that should be used for building....

I don't think that must be varied a lot... just keeping that to the lowest supported version (at least until there is a major version update) should be enough...

The tests then will test the compatibility of the built artifact with several DR versions - which should be the final and real test